### PR TITLE
feature/member-profile_update

### DIFF
--- a/src/main/java/com/pintor/purchase_reservation_system/common/config/AppConfig.java
+++ b/src/main/java/com/pintor/purchase_reservation_system/common/config/AppConfig.java
@@ -12,6 +12,7 @@ public class AppConfig {
 
     public static final String EMAIL_REGEX = "^[a-zA-Z0-9]+[._-]?[a-zA-Z0-9]+@[a-zA-Z0-9._-]+\\.[a-zA-Z]{2,}(\\.[a-zA-Z]{2,})?$";
     public static final String PASSWORD_REGEX = "^(?=.*[0-9])(?=.*[a-z])(?=.*[A-Z])(?=.*[!@#$%^&*+=_])(?=\\S+$).{8,}$";
+    public static final String PHONE_NUMBER_REGEX = "^01(?:0|1|[6-9])-(?:\\d{3}|\\d{4})-\\d{4}$";
 
     @Value("${aes.secret.key}")
     private String AES_SECRET_KEY;

--- a/src/main/java/com/pintor/purchase_reservation_system/common/config/AsyncConfig.java
+++ b/src/main/java/com/pintor/purchase_reservation_system/common/config/AsyncConfig.java
@@ -1,0 +1,9 @@
+package com.pintor.purchase_reservation_system.common.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.scheduling.annotation.EnableAsync;
+
+@EnableAsync
+@Configuration
+public class AsyncConfig {
+}

--- a/src/main/java/com/pintor/purchase_reservation_system/common/config/SecurityConfig.java
+++ b/src/main/java/com/pintor/purchase_reservation_system/common/config/SecurityConfig.java
@@ -29,7 +29,7 @@ public class SecurityConfig {
                 .securityMatcher("/api/**")
                 .authorizeHttpRequests(authorizeHttpRequests -> authorizeHttpRequests
                                 .requestMatchers(HttpMethod.POST, "/api/members").permitAll()
-                                .requestMatchers(HttpMethod.GET, "/api/auth/mail").permitAll()
+                                .requestMatchers(HttpMethod.POST, "/api/auth/verify/mail").permitAll()
                                 .requestMatchers(HttpMethod.POST, "/api/auth/login").permitAll()
                                 .anyRequest().authenticated()
                 )

--- a/src/main/java/com/pintor/purchase_reservation_system/common/errors/exception_hanlder/ApiAuthenticationExceptionHandler.java
+++ b/src/main/java/com/pintor/purchase_reservation_system/common/errors/exception_hanlder/ApiAuthenticationExceptionHandler.java
@@ -21,7 +21,9 @@ public class ApiAuthenticationExceptionHandler implements AuthenticationEntryPoi
 
         ResData resData;
         Long id = (Long) request.getAttribute("token_validation_level");
-        if (id == -1) {
+        if (id == null) {
+            resData= ResData.of(FailCode.UNAUTHORIZED);
+        } else if (id == -1) {
             resData = ResData.of(FailCode.EXPIRED_ACCESS_TOKEN);
         } else if (id == -2) {
             resData = ResData.of(FailCode.INVALID_ACCESS_TOKEN);

--- a/src/main/java/com/pintor/purchase_reservation_system/common/response/FailCode.java
+++ b/src/main/java/com/pintor/purchase_reservation_system/common/response/FailCode.java
@@ -22,6 +22,7 @@ public enum FailCode {
     INVALID_ACCESS_TOKEN(HttpStatus.UNAUTHORIZED, "invalid access token", "유효하지 않은 인증 토큰입니다"),
     UNAUTHORIZED(HttpStatus.UNAUTHORIZED, "unauthorized", "인증되지 않은 사용자입니다"),
     FORBIDDEN(HttpStatus.FORBIDDEN, "forbidden", "권한이 없습니다"),
+    EMAIL_NOT_VERIFIED(HttpStatus.FORBIDDEN, "email not verified", "이메일 인증을 완료해주세요"),
 
     // Server Fail Code
     MAIL_SEND_FAIL(HttpStatus.INTERNAL_SERVER_ERROR, "mail send fail", "메일 발송 중 오류가 발생했습니다"),

--- a/src/main/java/com/pintor/purchase_reservation_system/common/response/FailCode.java
+++ b/src/main/java/com/pintor/purchase_reservation_system/common/response/FailCode.java
@@ -13,6 +13,8 @@ public enum FailCode {
     PASSWORD_NOT_MATCH(HttpStatus.BAD_REQUEST, "password not match", "비밀번호가 일치하지 않습니다"),
     INVALID_ADDRESS(HttpStatus.BAD_REQUEST, "invalid address", "올바르지 않은 주소입니다"),
     MEMBER_NOT_FOUND(HttpStatus.NOT_FOUND, "member not found", "회원을 찾을 수 없습니다"),
+    INVALID_ZONECODE_AND_ADDRESS(HttpStatus.BAD_REQUEST, "invalid zoneCode and address", "zoneCode와 address는 둘 다 채워지거나 둘 다 비워져야 합니다"),
+    INVALID_SUBADDRESS(HttpStatus.BAD_REQUEST, "invalid subAddress", "subAddress는 zoneCode와 address가 채워져 있을 때만 채워질 수 있습니다"),
 
     // Auth Service Fail Code
     INVALID_MAIL_TOKEN(HttpStatus.BAD_REQUEST, "invalid mail token", "유효하지 않은 메일 토큰입니다"),

--- a/src/main/java/com/pintor/purchase_reservation_system/common/response/SuccessCode.java
+++ b/src/main/java/com/pintor/purchase_reservation_system/common/response/SuccessCode.java
@@ -9,7 +9,8 @@ public enum SuccessCode {
     SIGNUP(HttpStatus.CREATED, "signup", "회원가입에 성공하였습니다"),
     VERIFY_MAIL(HttpStatus.OK, "verify mail", "이메일 인증에 성공하였습니다"),
     LOGIN(HttpStatus.OK, "login", "인증 토큰을 반환합니다"),
-    LOGOUT(HttpStatus.OK, "logout", "로그아웃에 성공하였습니다"),;
+    LOGOUT(HttpStatus.OK, "logout", "로그아웃에 성공하였습니다"),
+    PROFILE_UPDATE(HttpStatus.OK, "profile update", "프로필 업데이트가 완료되었습니다");
 
     private HttpStatus status;
     private String code;

--- a/src/main/java/com/pintor/purchase_reservation_system/common/response/SuccessCode.java
+++ b/src/main/java/com/pintor/purchase_reservation_system/common/response/SuccessCode.java
@@ -10,7 +10,8 @@ public enum SuccessCode {
     VERIFY_MAIL(HttpStatus.OK, "verify mail", "이메일 인증에 성공하였습니다"),
     LOGIN(HttpStatus.OK, "login", "인증 토큰을 반환합니다"),
     LOGOUT(HttpStatus.OK, "logout", "로그아웃에 성공하였습니다"),
-    PROFILE_UPDATE(HttpStatus.OK, "profile update", "프로필 업데이트가 완료되었습니다");
+    PROFILE_UPDATE(HttpStatus.OK, "profile update", "프로필 업데이트가 완료되었습니다"),
+    PASSWORD_UPDATE(HttpStatus.OK, "password update", "비밀번호 업데이트가 완료되었습니다");
 
     private HttpStatus status;
     private String code;

--- a/src/main/java/com/pintor/purchase_reservation_system/common/service/MailService.java
+++ b/src/main/java/com/pintor/purchase_reservation_system/common/service/MailService.java
@@ -8,6 +8,7 @@ import jakarta.mail.internet.MimeMessage;
 import lombok.RequiredArgsConstructor;
 import org.springframework.mail.javamail.JavaMailSender;
 import org.springframework.mail.javamail.MimeMessageHelper;
+import org.springframework.scheduling.annotation.Async;
 import org.springframework.stereotype.Service;
 
 @RequiredArgsConstructor
@@ -16,6 +17,7 @@ public class MailService {
 
     private final JavaMailSender javaMailSender;
 
+    @Async
     public void sendVerificationCode(String email, String code) {
         MimeMessage mimeMessage = this.javaMailSender.createMimeMessage();
         MimeMessageHelper helper = null;

--- a/src/main/java/com/pintor/purchase_reservation_system/common/service/MailService.java
+++ b/src/main/java/com/pintor/purchase_reservation_system/common/service/MailService.java
@@ -26,7 +26,7 @@ public class MailService {
 
             String title = "PRS 이메일 인증 링크 발송 메일입니다";
             String content = new StringBuilder("아래 링크로 접속하시면 이메일 인증이 완료됩니다<br>")
-                    .append("http://localhost:8082/api/auth/mail?code=")
+                    .append("http://localhost:8082/auth/mail?code=")
                     .append(code)
                     .toString();
 

--- a/src/main/java/com/pintor/purchase_reservation_system/domain/member_module/auth/controller/AuthController.java
+++ b/src/main/java/com/pintor/purchase_reservation_system/domain/member_module/auth/controller/AuthController.java
@@ -3,6 +3,7 @@ package com.pintor.purchase_reservation_system.domain.member_module.auth.control
 import com.pintor.purchase_reservation_system.common.response.ResData;
 import com.pintor.purchase_reservation_system.common.response.SuccessCode;
 import com.pintor.purchase_reservation_system.domain.member_module.auth.request.AuthLoginRequest;
+import com.pintor.purchase_reservation_system.domain.member_module.auth.request.AuthVerifyMailRequest;
 import com.pintor.purchase_reservation_system.domain.member_module.auth.response.AuthLoginResponse;
 import com.pintor.purchase_reservation_system.domain.member_module.auth.service.AuthService;
 import com.pintor.purchase_reservation_system.domain.member_module.member.service.MemberService;
@@ -25,10 +26,10 @@ public class AuthController {
     private final AuthService authService;
     private final MemberService memberService;
 
-    @GetMapping(value = "/mail", consumes = MediaType.ALL_VALUE)
-    public ResponseEntity verifyMail(@RequestParam(value = "code") String code) {
+    @PostMapping(value = "/verify/mail", consumes = MediaType.ALL_VALUE)
+    public ResponseEntity verifyMail(@Valid @RequestBody AuthVerifyMailRequest request, BindingResult bindingResult) {
 
-        Long memberId = this.authService.verifyMailToken(code);
+        Long memberId = this.authService.verifyMailToken(request, bindingResult);
         this.memberService.verifyEmail(memberId);
 
         ResData resData = ResData.of(

--- a/src/main/java/com/pintor/purchase_reservation_system/domain/member_module/auth/entity/AuthToken.java
+++ b/src/main/java/com/pintor/purchase_reservation_system/domain/member_module/auth/entity/AuthToken.java
@@ -5,7 +5,6 @@ import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.experimental.SuperBuilder;
-import org.springframework.beans.factory.annotation.Value;
 import org.springframework.data.annotation.Id;
 import org.springframework.data.redis.core.RedisHash;
 import org.springframework.data.redis.core.TimeToLive;
@@ -27,6 +26,5 @@ public class AuthToken {
     private String accessToken;
 
     @TimeToLive
-    @Value("${jwt.expiration.refresh_token}")
     private Long timeToLive;
 }

--- a/src/main/java/com/pintor/purchase_reservation_system/domain/member_module/auth/entity/MailToken.java
+++ b/src/main/java/com/pintor/purchase_reservation_system/domain/member_module/auth/entity/MailToken.java
@@ -5,7 +5,6 @@ import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.experimental.SuperBuilder;
-import org.springframework.beans.factory.annotation.Value;
 import org.springframework.data.annotation.Id;
 import org.springframework.data.redis.core.RedisHash;
 import org.springframework.data.redis.core.TimeToLive;
@@ -23,6 +22,5 @@ public class MailToken {
     private Long memberId;
 
     @TimeToLive
-    @Value("${mail.expiration}")
     private Long timeToLive;
 }

--- a/src/main/java/com/pintor/purchase_reservation_system/domain/member_module/auth/request/AuthVerifyMailRequest.java
+++ b/src/main/java/com/pintor/purchase_reservation_system/domain/member_module/auth/request/AuthVerifyMailRequest.java
@@ -1,0 +1,17 @@
+package com.pintor.purchase_reservation_system.domain.member_module.auth.request;
+
+import jakarta.validation.constraints.NotBlank;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class AuthVerifyMailRequest {
+
+    @NotBlank(message = "Code is required")
+    private String code;
+}

--- a/src/main/java/com/pintor/purchase_reservation_system/domain/member_module/auth/service/AuthService.java
+++ b/src/main/java/com/pintor/purchase_reservation_system/domain/member_module/auth/service/AuthService.java
@@ -128,6 +128,17 @@ public class AuthService {
             );
         }
 
+        if (!member.isEmailVerified()) {
+
+            log.error("email not verified: {}", request.getEmail());
+
+            throw new ApiResException(
+                    ResData.of(
+                            FailCode.EMAIL_NOT_VERIFIED
+                    )
+            );
+        }
+
         return member;
     }
 

--- a/src/main/java/com/pintor/purchase_reservation_system/domain/member_module/auth/service/AuthService.java
+++ b/src/main/java/com/pintor/purchase_reservation_system/domain/member_module/auth/service/AuthService.java
@@ -16,6 +16,7 @@ import com.pintor.purchase_reservation_system.domain.member_module.member.entity
 import com.pintor.purchase_reservation_system.domain.member_module.member.repository.MemberRepository;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.validation.BindingResult;
@@ -27,6 +28,12 @@ import java.security.SecureRandom;
 @RequiredArgsConstructor
 @Service
 public class AuthService {
+
+    @Value("${mail.expiration}")
+    private Long mailTokenExpiration;
+
+    @Value("${jwt.expiration.refresh_token}")
+    private Long authTokenExpiration;
 
     private final MailTokenRepository mailTokenRepository;
     private final MemberRepository memberRepository;
@@ -43,6 +50,7 @@ public class AuthService {
         MailToken mailToken = MailToken.builder()
                 .id(code)
                 .memberId(memberId)
+                .timeToLive(this.mailTokenExpiration)
                 .build();
 
         this.mailTokenRepository.save(mailToken);
@@ -169,6 +177,7 @@ public class AuthService {
                 .id(member.getId())
                 .refreshToken(refreshToken)
                 .accessToken(accessToken)
+                .timeToLive(this.authTokenExpiration)
                 .build();
 
         this.authTokenRepository.save(authToken);

--- a/src/main/java/com/pintor/purchase_reservation_system/domain/member_module/member/controller/MemberController.java
+++ b/src/main/java/com/pintor/purchase_reservation_system/domain/member_module/member/controller/MemberController.java
@@ -5,6 +5,7 @@ import com.pintor.purchase_reservation_system.common.response.SuccessCode;
 import com.pintor.purchase_reservation_system.common.service.MailService;
 import com.pintor.purchase_reservation_system.domain.member_module.auth.service.AuthService;
 import com.pintor.purchase_reservation_system.domain.member_module.member.entity.Member;
+import com.pintor.purchase_reservation_system.domain.member_module.member.request.MemberProfileUpdateRequest;
 import com.pintor.purchase_reservation_system.domain.member_module.member.request.MemberSignupRequest;
 import com.pintor.purchase_reservation_system.domain.member_module.member.response.MemberSignupResponse;
 import com.pintor.purchase_reservation_system.domain.member_module.member.service.MemberService;
@@ -13,11 +14,10 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.security.core.userdetails.User;
 import org.springframework.validation.BindingResult;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 @Slf4j
 @RequestMapping(value = "/api/members", consumes = MediaType.APPLICATION_JSON_VALUE, produces = MediaType.APPLICATION_JSON_VALUE)
@@ -41,6 +41,22 @@ public class MemberController {
         ResData resData = ResData.of(
                 SuccessCode.SIGNUP,
                 MemberSignupResponse.of(member)
+        );
+        return ResponseEntity
+                .status(resData.getStatus())
+                .body(resData);
+    }
+
+    @PatchMapping
+    public ResponseEntity profileUpdate(@Valid @RequestBody MemberProfileUpdateRequest request, BindingResult bindingResult,
+                                        @AuthenticationPrincipal User user) {
+
+        log.info("profile update request: {}", request);
+
+        this.memberService.profileUpdate(request, bindingResult, user);
+
+        ResData resData = ResData.of(
+                SuccessCode.PROFILE_UPDATE
         );
         return ResponseEntity
                 .status(resData.getStatus())

--- a/src/main/java/com/pintor/purchase_reservation_system/domain/member_module/member/controller/MemberController.java
+++ b/src/main/java/com/pintor/purchase_reservation_system/domain/member_module/member/controller/MemberController.java
@@ -5,6 +5,7 @@ import com.pintor.purchase_reservation_system.common.response.SuccessCode;
 import com.pintor.purchase_reservation_system.common.service.MailService;
 import com.pintor.purchase_reservation_system.domain.member_module.auth.service.AuthService;
 import com.pintor.purchase_reservation_system.domain.member_module.member.entity.Member;
+import com.pintor.purchase_reservation_system.domain.member_module.member.request.MemberPasswordUpdateRequest;
 import com.pintor.purchase_reservation_system.domain.member_module.member.request.MemberProfileUpdateRequest;
 import com.pintor.purchase_reservation_system.domain.member_module.member.request.MemberSignupRequest;
 import com.pintor.purchase_reservation_system.domain.member_module.member.response.MemberSignupResponse;
@@ -57,6 +58,22 @@ public class MemberController {
 
         ResData resData = ResData.of(
                 SuccessCode.PROFILE_UPDATE
+        );
+        return ResponseEntity
+                .status(resData.getStatus())
+                .body(resData);
+    }
+
+    @PatchMapping(value = "/password")
+    public ResponseEntity passwordUpdate(@Valid @RequestBody MemberPasswordUpdateRequest request, BindingResult bindingResult,
+                                         @AuthenticationPrincipal User user) {
+
+        log.info("password update request: {}", request);
+
+        this.memberService.passwordUpdate(request, bindingResult, user);
+
+        ResData resData = ResData.of(
+                SuccessCode.PASSWORD_UPDATE
         );
         return ResponseEntity
                 .status(resData.getStatus())

--- a/src/main/java/com/pintor/purchase_reservation_system/domain/member_module/member/entity/Member.java
+++ b/src/main/java/com/pintor/purchase_reservation_system/domain/member_module/member/entity/Member.java
@@ -35,7 +35,16 @@ public class Member extends BaseEntity {
     private String password;
 
     @Convert(converter = MemberConverter.class)
+    private String phoneNumber;
+
+    @Convert(converter = MemberConverter.class)
+    private String zoneCode;
+
+    @Convert(converter = MemberConverter.class)
     private String address;
+
+    @Convert(converter = MemberConverter.class)
+    private String subAddress;
 
     private boolean emailVerified;
 

--- a/src/main/java/com/pintor/purchase_reservation_system/domain/member_module/member/request/MemberPasswordUpdateRequest.java
+++ b/src/main/java/com/pintor/purchase_reservation_system/domain/member_module/member/request/MemberPasswordUpdateRequest.java
@@ -1,0 +1,26 @@
+package com.pintor.purchase_reservation_system.domain.member_module.member.request;
+
+import com.pintor.purchase_reservation_system.common.config.AppConfig;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Pattern;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class MemberPasswordUpdateRequest {
+
+    @NotBlank(message = "Old password is required")
+    private String oldPassword;
+
+    @NotBlank(message = "New password is required")
+    @Pattern(regexp = AppConfig.PASSWORD_REGEX, message = "Password must contain at least 8 characters, one uppercase, one lowercase, one number and one special character")
+    private String newPassword;
+
+    @NotBlank(message = "New password confirmation is required")
+    private String newPasswordConfirm;
+}

--- a/src/main/java/com/pintor/purchase_reservation_system/domain/member_module/member/request/MemberProfileUpdateRequest.java
+++ b/src/main/java/com/pintor/purchase_reservation_system/domain/member_module/member/request/MemberProfileUpdateRequest.java
@@ -1,0 +1,24 @@
+package com.pintor.purchase_reservation_system.domain.member_module.member.request;
+
+import com.pintor.purchase_reservation_system.common.config.AppConfig;
+import jakarta.validation.constraints.Pattern;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class MemberProfileUpdateRequest {
+
+    @Pattern(regexp = AppConfig.PHONE_NUMBER_REGEX, message = "Invalid phone number format")
+    private String phoneNumber;
+
+    private String zoneCode;
+
+    private String address;
+
+    private String subAddress;
+}

--- a/src/main/java/com/pintor/purchase_reservation_system/domain/member_module/member/request/MemberSignupRequest.java
+++ b/src/main/java/com/pintor/purchase_reservation_system/domain/member_module/member/request/MemberSignupRequest.java
@@ -28,6 +28,10 @@ public class MemberSignupRequest {
     @NotBlank(message = "Password confirmation is required")
     private String passwordConfirm;
 
+    @NotBlank(message = "Phone number is required")
+    @Pattern(regexp = AppConfig.PHONE_NUMBER_REGEX, message = "Invalid phone number format")
+    private String phoneNumber;
+
     @NotBlank(message = "Zone code is required")
     private String zoneCode;
 

--- a/src/main/java/com/pintor/purchase_reservation_system/domain/member_module/member/service/MemberService.java
+++ b/src/main/java/com/pintor/purchase_reservation_system/domain/member_module/member/service/MemberService.java
@@ -6,7 +6,6 @@ import com.pintor.purchase_reservation_system.common.errors.exception.ApiResExce
 import com.pintor.purchase_reservation_system.common.response.FailCode;
 import com.pintor.purchase_reservation_system.common.response.ResData;
 import com.pintor.purchase_reservation_system.common.service.EncryptService;
-import com.pintor.purchase_reservation_system.domain.member_module.auth.service.AuthService;
 import com.pintor.purchase_reservation_system.domain.member_module.member.entity.Member;
 import com.pintor.purchase_reservation_system.domain.member_module.member.repository.MemberRepository;
 import com.pintor.purchase_reservation_system.domain.member_module.member.request.MemberSignupRequest;
@@ -33,7 +32,6 @@ public class MemberService {
     private final MemberRepository memberRepository;
 
     private final EncryptService encryptService;
-    private final AuthService authService;
 
     private final WebClient webClient;
     private final ObjectMapper objectMapper;
@@ -48,7 +46,10 @@ public class MemberService {
                 .email(request.getEmail())
                 .name(request.getName())
                 .password(this.encryptService.encode(request.getPassword()))
+                .phoneNumber(request.getPhoneNumber())
+                .zoneCode(request.getZoneCode())
                 .address(request.getAddress())
+                .subAddress(request.getSubAddress() == null ? "" : request.getSubAddress())
                 .build();
 
         return this.memberRepository.save(member);
@@ -113,8 +114,7 @@ public class MemberService {
     }
 
     private boolean isDuplicatedEmail(String email) {
-        String encryptedEmail = this.encryptService.encrypt(email);
-        return this.memberRepository.existsByEmail(encryptedEmail);
+        return this.memberRepository.existsByEmail(email);
     }
 
     private boolean isValidAddress(String zoneCode, String address) {


### PR DESCRIPTION
## #️⃣ 연관된 이슈
#10 

## 📌 PR 유형
- [x] 신규 기능
- [x] 버그 수정

## 📝 작업 내용
- [x] 주소, 전화번호를 업데이트 할 수 있다.
- [x] 비밀번호를 업데이트 할 수 있다.
- [x] 멤버 엔티티에 phoneNumber, zoneCode, subAddress 저장하도록 수정
- [x] 메일 발송 메서드 비동기로 변경
- [x] 로그인 시 이메일 인증 여부 확인하도록 변경
- [x] 이메일 인증 메서드 POST로 변경 및 부가 작업
- [x] redis ttl 설정 오류 수정